### PR TITLE
Fix for false dragstart events in firefox for RSV

### DIFF
--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1537,6 +1537,9 @@ export class Viewer {
 
   set_dropzone(zone: HTMLElement, callback: (arg: File) => void) {
     const self = this;
+    zone.addEventListener('dragstart', function (e: DragEvent) {
+      e.preventDefault();
+    });
     zone.addEventListener('dragover', function (e: DragEvent) {
       e.stopPropagation();
       e.preventDefault();

--- a/uglymol.js
+++ b/uglymol.js
@@ -7828,6 +7828,9 @@ Viewer.prototype.load_file = function load_file (url, options,
 
 Viewer.prototype.set_dropzone = function set_dropzone (zone, callback) {
   var self = this;
+  zone.addEventListener('dragstart', function (e) {
+    e.preventDefault();
+  });
   zone.addEventListener('dragover', function (e) {
     e.stopPropagation();
     e.preventDefault();


### PR DESCRIPTION
Fix for https://github.com/uglymol/uglymol/issues/14.

This basically just prevents a dragstart event from occurring in the reciprocal space viewer.